### PR TITLE
Allow to specify custom border with and color

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ You can also add borders to ranges of cells:
 
 ```ruby
 sheet.add_border 'B2:D5'
-sheet.add_border 'B2:D5', [:right]
-sheet.add_border 'B2:D5', [:right], :thick
-border_color = 'FF0000'
-sheet.add_border 'B2:D5', [:right], :medium, border_color
+sheet.add_border 'B2:D5', [:bottom, :right]
+sheet.add_border 'B2:D5', { edges: [:bottom, :right], style: :thick, color: 'FF0000' }
 ```
 
-When you are done with styling you just need to run
+Border parameters are optional. The default is to draw a thin black border on all four edges of the selected cell range.
+
+The styles are applied with a simple call:
 
 ```ruby
 workbook.apply_styles
@@ -80,7 +80,7 @@ workbook.add_worksheet do |sheet|
   sheet.add_style 'B3:D5', bg_color: 'E2F89C'
   sheet.add_style 'D3:D5', alignment: { horizontal: :left }
   sheet.add_border 'B2:D5'
-  sheet.add_border 'B3:D3', [:top], :medium
+  sheet.add_border 'B3:D3', [:top]
 end
 workbook.apply_styles
 axlsx.serialize 'grocery.xlsx'

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ You can also add borders to ranges of cells:
 ```ruby
 sheet.add_border 'B2:D5'
 sheet.add_border 'B2:D5', [:right]
+sheet.add_border 'B2:D5', [:right], :thick
+border_color = 'FF0000'
+sheet.add_border 'B2:D5', [:right], :medium, border_color
 ```
 
 When you are done with styling you just need to run
@@ -77,7 +80,7 @@ workbook.add_worksheet do |sheet|
   sheet.add_style 'B3:D5', bg_color: 'E2F89C'
   sheet.add_style 'D3:D5', alignment: { horizontal: :left }
   sheet.add_border 'B2:D5'
-  sheet.add_border 'B3:D3', [:top]
+  sheet.add_border 'B3:D3', [:top], :medium
 end
 workbook.apply_styles
 axlsx.serialize 'grocery.xlsx'
@@ -106,7 +109,7 @@ wb.add_worksheet do |sheet|
     border: { style: :thin, color: border_color, edges: [:top, :right, :bottom] }
   })
   sheet.add_row
-  sheet.add_row(["", "Product", "Category", "Price"], 
+  sheet.add_row(["", "Product", "Category", "Price"],
     style: [ nil, top_left_corner, top_edge, top_right_corner ]
   )
 

--- a/examples/colors_and_borders.rb
+++ b/examples/colors_and_borders.rb
@@ -17,7 +17,7 @@ workbook.add_worksheet do |sheet|
   sheet.add_style 'B3:D5', bg_color: 'E2F89C'
   sheet.add_style 'D3:D5', alignment: { horizontal: :left }
   sheet.add_border 'B2:D5'
-  sheet.add_border 'B3:D3', [:top]
+  sheet.add_border 'B3:D3', [:top], :thick
 end
 workbook.apply_styles
 axlsx.serialize File.expand_path('../../tmp/grocery.xlsx', __FILE__)

--- a/lib/axlsx_styler/axlsx_worksheet.rb
+++ b/lib/axlsx_styler/axlsx_worksheet.rb
@@ -25,9 +25,10 @@ module AxlsxStyler
       #   add_border 'B2:F8', [:left, :top], :medium
       #   add_border 'C2:G10', [:top]
       #   add_border 'C2:G10'
-      def add_border(cell_ref, edges = :all, width = :thin, color = '000000')
+      #   add_border 'B2:D5', { style: :thick, color: '00330f', edges: [:left, :right] }
+      def add_border(cell_ref, args = :all)
         cells = self[cell_ref]
-        BorderCreator.new(self, cells, edges, width, color).draw
+        BorderCreator.new(self, cells, args).draw
       end
     end
   end

--- a/lib/axlsx_styler/axlsx_worksheet.rb
+++ b/lib/axlsx_styler/axlsx_worksheet.rb
@@ -21,13 +21,13 @@ module AxlsxStyler
       end
 
       # Examples:
-      #   add_border 'B2:F8', [:left, :top]
+      #   add_border 'B2:F8', [:left, :top], :medium, '00330f'
+      #   add_border 'B2:F8', [:left, :top], :medium
       #   add_border 'C2:G10', [:top]
       #   add_border 'C2:G10'
-      # @TODO: allow to pass in custom border style
-      def add_border(cell_ref, edges = :all)
+      def add_border(cell_ref, edges = :all, width = :thin, color = '000000')
         cells = self[cell_ref]
-        BorderCreator.new(self, cells, edges).draw
+        BorderCreator.new(self, cells, edges, width, color).draw
       end
     end
   end

--- a/lib/axlsx_styler/border_creator.rb
+++ b/lib/axlsx_styler/border_creator.rb
@@ -1,14 +1,16 @@
 class BorderCreator
-  attr_reader :worksheet, :cells, :edges
+  attr_reader :worksheet, :cells, :edges, :width, :color
 
-  def initialize(worksheet, cells, edges)
+  def initialize(worksheet, cells, edges, width, color)
     @worksheet = worksheet
     @cells     = cells
     @edges     = edges
+    @width     = width
+    @color     = color
   end
 
   def draw
-    selected_edges(edges).each { |edge| add_border(edge) }
+    selected_edges(edges).each { |edge| add_border(edge, width, color) }
   end
 
   private
@@ -24,10 +26,10 @@ class BorderCreator
     end
   end
 
-  def add_border(position)
+  def add_border(position, width, color)
     style = {
       border: {
-        style: :thin, color: '000000', edges: [position.to_sym]
+        style: width, color: color, edges: [position.to_sym]
       }
     }
     worksheet.add_style border_cells[position.to_sym], style

--- a/lib/axlsx_styler/border_creator.rb
+++ b/lib/axlsx_styler/border_creator.rb
@@ -1,12 +1,18 @@
 class BorderCreator
   attr_reader :worksheet, :cells, :edges, :width, :color
 
-  def initialize(worksheet, cells, edges, width, color)
+  def initialize(worksheet, cells, args)
     @worksheet = worksheet
     @cells     = cells
-    @edges     = edges
-    @width     = width
-    @color     = color
+    if args.is_a?(Hash)
+      @edges = args[:edges] || :all
+      @width = args[:width] || :thin
+      @color = args[:color] || '000000'
+    else
+      @edges = args || :all
+      @width = :thin
+      @color = '000000'
+    end
   end
 
   def draw
@@ -33,7 +39,6 @@ class BorderCreator
       }
     }
     worksheet.add_style border_cells[position.to_sym], style
-    # add_style border_cells(cell_ref)[position.to_sym], style
   end
 
   def border_cells

--- a/lib/axlsx_styler/border_creator.rb
+++ b/lib/axlsx_styler/border_creator.rb
@@ -6,7 +6,7 @@ class BorderCreator
     @cells     = cells
     if args.is_a?(Hash)
       @edges = args[:edges] || :all
-      @width = args[:width] || :thin
+      @width = args[:style] || :thin
       @color = args[:color] || '000000'
     else
       @edges = args || :all

--- a/lib/axlsx_styler/version.rb
+++ b/lib/axlsx_styler/version.rb
@@ -1,3 +1,3 @@
 module AxlsxStyler
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -31,8 +31,8 @@ class IntegrationTest < MiniTest::Test
       sheet.add_style 'D3:D6', alignment: { horizontal: :left }
       sheet.add_border 'B2:D6'
       sheet.add_border 'B3:D3', [:top]
-      sheet.add_border 'B3:D3', [:bottom], :medium
-      sheet.add_border 'B3:D3', [:bottom], :medium, '32f332'
+      sheet.add_border 'B3:D3', edges: [:bottom], style: :medium
+      sheet.add_border 'B3:D3', edges: [:bottom], style: :medium, color: '32f332'
     end
     @workbook.apply_styles
     assert_equal 12, @workbook.style_index.count

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -39,6 +39,57 @@ class IntegrationTest < MiniTest::Test
     assert_equal 12 + 2, @workbook.style_index.keys.max
   end
 
+  def test_duplicate_borders
+    @filename = 'duplicate_borders_test'
+    @workbook.add_worksheet do |sheet|
+      sheet.add_row
+      sheet.add_row ['', 'B2', 'C2', 'D2']
+      sheet.add_row ['', 'B3', 'C3', 'D3']
+      sheet.add_row ['', 'B4', 'C4', 'D4']
+
+      sheet.add_border 'B2:D4'
+      sheet.add_border 'B2:D4'
+    end
+    @workbook.apply_styles
+    assert_equal 8, @workbook.style_index.count
+    assert_equal 8, @workbook.styled_cells.count
+  end
+
+  def test_multiple_style_borders_on_same_sells
+    @filename = 'multiple_style_borders'
+    @workbook.add_worksheet do |sheet|
+      sheet.add_row
+      sheet.add_row ['', 'B2', 'C2', 'D2']
+      sheet.add_row ['', 'B3', 'C3', 'D3']
+
+      sheet.add_border 'B2:D3', :all
+      sheet.add_border 'B2:D2', edges: [:bottom], style: :thick, color: 'ff0000'
+    end
+    @workbook.apply_styles
+    assert_equal 6, @workbook.style_index.count
+    assert_equal 6, @workbook.styled_cells.count
+
+    b2_cell_style = {
+      border: {
+        style: :thick,
+        color: 'ff0000',
+        edges: [:top, :left, :bottom]
+      }
+    }
+    assert_equal b2_cell_style, @workbook.style_index
+      .find { |_, v| v[:border][:edges] == [:top, :left, :bottom] }[1]
+
+    d3_cell_style = {
+      border: {
+        style: :thin,
+        color: '000000',
+        edges: [:right, :bottom]
+      }
+    }
+    assert_equal d3_cell_style, @workbook.style_index
+      .find { |_, v| v[:border][:edges] == [:right, :bottom] }[1]
+  end
+
   def test_table_with_num_fmt
     @filename = 'num_fmt_test'
     t = Time.now

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -31,6 +31,8 @@ class IntegrationTest < MiniTest::Test
       sheet.add_style 'D3:D6', alignment: { horizontal: :left }
       sheet.add_border 'B2:D6'
       sheet.add_border 'B3:D3', [:top]
+      sheet.add_border 'B3:D3', [:bottom], :medium
+      sheet.add_border 'B3:D3', [:bottom], :medium, '32f332'
     end
     @workbook.apply_styles
     assert_equal 12, @workbook.style_index.count


### PR DESCRIPTION
This change is based on the pull request from @archferns. To apply some optional border parameters one can pass a Hash of options which is in line with to how `axlsx` gem implements it:

``` ruby
sheet.add_border 'B2:D2', { edges: [:bottom], style: :thick, color: 'ff0000' }
```

Old syntax is also supported:
``` ruby
sheet.add_border 'B2:D2', [:top, :left]
```

This pull request is an updated version of https://github.com/sakovias/axlsx_styler/pull/3.