### PR TITLE
Make apply_styles call optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ row is created.
 a spreadsheet with data and apply styles later. Paired with
 [axlsx_rails](https://github.com/straydogstudio/axlsx_rails) this gem
 allows to build clean and maintainable Excel views in a Rails app. It can also
-be used outside of any specific ruby framework as shown in example below.
+be used outside of any specific Ruby framework as shown in example below.
 
 ## Usage
 
@@ -44,18 +44,12 @@ sheet.add_border 'B2:D5', { edges: [:bottom, :right], style: :thick, color: 'FF0
 
 Border parameters are optional. The default is to draw a thin black border on all four edges of the selected cell range.
 
-The styles are applied with a simple call:
 
-```ruby
-workbook.apply_styles
-```
+### Example
 
-Here's an example that compares styling a simple table with and without
-`axlsx_styler`. Suppose we wand to create the following spreadsheet:
+Suppose we want create the following spreadsheet:
 
 ![alt text](./spreadsheet.png "Sample Spreadsheet")
-
-### `axlsx` paired with `axlsx_styler`
 
 You can apply styles after all data is entered, similar to how you'd create
 an Excel document by hand:
@@ -82,92 +76,16 @@ workbook.add_worksheet do |sheet|
   sheet.add_border 'B2:D5'
   sheet.add_border 'B3:D3', [:top]
 end
-workbook.apply_styles
 axlsx.serialize 'grocery.xlsx'
 ```
 
-### `axlsx` gem without `axlsx_styler`
+Producing the same spreadsheet with vanilla `axlsx` turns out [a bit trickier](./examples/vanilla_axlsx.md).
 
-Whith plain `axlsx` you need to know which styles you're going to use beforehand.
-The code for our example is a bit more envolved:
 
-```ruby
-require 'axlsx'
-axlsx = Axlsx::Package.new
-wb = axlsx.workbook
-border_color = '000000'
-wb.add_worksheet do |sheet|
-  # top row
-  header_hash = { b: true, bg_color: '95AFBA' }
-  top_left_corner = wb.styles.add_style header_hash.merge({
-    border: { style: :thin, color: border_color, edges: [:top, :left, :bottom] }
-  })
-  top_edge = wb.styles.add_style header_hash.merge({
-    border: { style: :thin, color: border_color, edges: [:top, :bottom] }
-  })
-  top_right_corner = wb.styles.add_style header_hash.merge({
-    border: { style: :thin, color: border_color, edges: [:top, :right, :bottom] }
-  })
-  sheet.add_row
-  sheet.add_row(["", "Product", "Category", "Price"],
-    style: [ nil, top_left_corner, top_edge, top_right_corner ]
-  )
+## Change log
 
-  # middle rows
-  color_hash = { bg_color: 'E2F89C' }
-  left_edge = wb.styles.add_style color_hash.merge(
-    b: true,
-    border: {
-      style: :thin, color: border_color, edges: [:left]
-    }
-  )
-  inner = wb.styles.add_style color_hash
-  right_edge = wb.styles.add_style color_hash.merge(
-    alignment: { horizontal: :left },
-    border: {
-      style: :thin, color: border_color, edges: [:right]
-    }
-  )
-  sheet.add_row(
-    ["", "Butter", "Dairy", 4.99],
-    style: [nil, left_edge, inner, right_edge]
-  )
-  sheet.add_row(
-    ["", "Bread", "Baked Goods", 3.45],
-    style: [nil, left_edge, inner, right_edge]
-  )
-
-  # last row
-  bottom_left_corner = wb.styles.add_style color_hash.merge({
-    b: true,
-    border: { style: :thin, color: border_color, edges: [:left, :bottom] }
-  })
-  bottom_edge = wb.styles.add_style color_hash.merge({
-    border: { style: :thin, color: border_color, edges: [:bottom] }
-  })
-  bottom_right_corner = wb.styles.add_style color_hash.merge({
-    alignment: { horizontal: :left },
-    border: { style: :thin, color: border_color, edges: [:right, :bottom] }
-  })
-  sheet.add_row(["", "Broccoli", "Produce", 2.99],
-    style: [nil, bottom_left_corner, bottom_edge, bottom_right_corner]
-  )
-
-  sheet.column_widths 5, 20, 20, 20
-end
-axlsx.serialize "grocery.xlsx"
-```
-
-## Installation
-
-Add this line to your application's Gemfile:
-
-    gem 'axlsx_styler'
-
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install axlsx_styler
+Version | Change
+--------|-------
+0.1.4 | Hide `workbook.apply_styles` method to make it usage easier.
+0.1.3 | Make border styles customazible.
+0.1.2 | Allow applying multiple style `Hash`es on a range of cells

--- a/README.md
+++ b/README.md
@@ -86,6 +86,6 @@ Producing the same spreadsheet with vanilla `axlsx` turns out [a bit trickier](.
 
 Version | Change
 --------|-------
-0.1.4 | Hide `workbook.apply_styles` method to make it usage easier.
+0.1.4 | Hide `Workbook#apply_styles` method to make it easier to use.
 0.1.3 | Make border styles customazible.
-0.1.2 | Allow applying multiple style `Hash`es on a range of cells
+0.1.2 | Allow applying multiple style hashes.

--- a/examples/vanilla_axlsx.md
+++ b/examples/vanilla_axlsx.md
@@ -1,0 +1,70 @@
+This gem is supposed to make styling spreadsheets easier.
+
+Here's how the [example from the README](../README.md) compares to that implemented with plain `axlsx`.
+
+```ruby
+require 'axlsx'
+axlsx = Axlsx::Package.new
+wb = axlsx.workbook
+border_color = '000000'
+wb.add_worksheet do |sheet|
+  # top row
+  header_hash = { b: true, bg_color: '95AFBA' }
+  top_left_corner = wb.styles.add_style header_hash.merge({
+    border: { style: :thin, color: border_color, edges: [:top, :left, :bottom] }
+  })
+  top_edge = wb.styles.add_style header_hash.merge({
+    border: { style: :thin, color: border_color, edges: [:top, :bottom] }
+  })
+  top_right_corner = wb.styles.add_style header_hash.merge({
+    border: { style: :thin, color: border_color, edges: [:top, :right, :bottom] }
+  })
+  sheet.add_row
+  sheet.add_row(["", "Product", "Category", "Price"],
+    style: [ nil, top_left_corner, top_edge, top_right_corner ]
+  )
+
+  # middle rows
+  color_hash = { bg_color: 'E2F89C' }
+  left_edge = wb.styles.add_style color_hash.merge(
+    b: true,
+    border: {
+      style: :thin, color: border_color, edges: [:left]
+    }
+  )
+  inner = wb.styles.add_style color_hash
+  right_edge = wb.styles.add_style color_hash.merge(
+    alignment: { horizontal: :left },
+    border: {
+      style: :thin, color: border_color, edges: [:right]
+    }
+  )
+  sheet.add_row(
+    ["", "Butter", "Dairy", 4.99],
+    style: [nil, left_edge, inner, right_edge]
+  )
+  sheet.add_row(
+    ["", "Bread", "Baked Goods", 3.45],
+    style: [nil, left_edge, inner, right_edge]
+  )
+
+  # last row
+  bottom_left_corner = wb.styles.add_style color_hash.merge({
+    b: true,
+    border: { style: :thin, color: border_color, edges: [:left, :bottom] }
+  })
+  bottom_edge = wb.styles.add_style color_hash.merge({
+    border: { style: :thin, color: border_color, edges: [:bottom] }
+  })
+  bottom_right_corner = wb.styles.add_style color_hash.merge({
+    alignment: { horizontal: :left },
+    border: { style: :thin, color: border_color, edges: [:right, :bottom] }
+  })
+  sheet.add_row(["", "Broccoli", "Produce", 2.99],
+    style: [nil, bottom_left_corner, bottom_edge, bottom_right_corner]
+  )
+
+  sheet.column_widths 5, 20, 20, 20
+end
+axlsx.serialize "grocery.xlsx"
+```

--- a/lib/axlsx_styler.rb
+++ b/lib/axlsx_styler.rb
@@ -8,3 +8,24 @@ require 'axlsx_styler/axlsx_cell'
 Axlsx::Workbook.send :include, AxlsxStyler::Axlsx::Workbook
 Axlsx::Worksheet.send :include, AxlsxStyler::Axlsx::Worksheet
 Axlsx::Cell.send :include, AxlsxStyler::Axlsx::Cell
+
+module Axlsx
+  class Package
+
+    # Patches the original Axlsx::Package#serialize method so that styles are
+    # applied when the workbook is saved
+    original_serialize = instance_method(:serialize)
+    define_method :serialize do |*args|
+      @workbook.apply_styles if !@workbook.styles_applied
+      original_serialize.bind(self).(*args)
+    end
+
+    # Patches the original Axlsx::Package#to_stream method so that styles are
+    # applied when the workbook is converted to StringIO
+    original_to_stream = instance_method(:to_stream)
+    define_method :to_stream do |*args|
+      @workbook.apply_styles if !@workbook.styles_applied
+      original_to_stream.bind(self).(*args)
+    end
+  end
+end

--- a/lib/axlsx_styler/axlsx_workbook.rb
+++ b/lib/axlsx_styler/axlsx_workbook.rb
@@ -4,6 +4,10 @@ module AxlsxStyler
       # An array that holds all cells with styles
       attr_accessor :styled_cells
 
+      # Checks if styles are idexed to make it work for pre 0.1.4 version
+      # users that still explicitly call @workbook.apply_styles
+      attr_accessor :styles_applied
+
       # An index for cell styles
       #   {
       #     1 => < style_hash >,
@@ -25,13 +29,13 @@ module AxlsxStyler
         styled_cells.each do |cell|
           set_style_index(cell)
         end
+        self.styles_applied = true
       end
 
       private
 
       # Check if style code
       def set_style_index(cell)
-        # @TODO fix this hack
         self.style_index ||= {}
 
         index_item = style_index.select { |_, v| v == cell.raw_style }.first

--- a/lib/axlsx_styler/version.rb
+++ b/lib/axlsx_styler/version.rb
@@ -1,3 +1,3 @@
 module AxlsxStyler
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -6,15 +6,22 @@ class IntegrationTest < MiniTest::Test
     @workbook = @axlsx.workbook
   end
 
-  # Save files in case you'd like to see what the result is
+  # Save to a file using Axlsx::Package#serialize
   def serialize(filename)
     @axlsx.serialize File.expand_path("../../tmp/#{filename}.xlsx", __FILE__)
     assert_equal true, @workbook.styles_applied
   end
 
-  # New functionality as of 0.1.4
-  def test_works_without_apply_styles
-    filename = 'without_apply_styles'
+  # Save to a file by getting contents from stream
+  def to_stream(filename)
+    File.open(File.expand_path("../../tmp/#{filename}.xlsx", __FILE__), 'w') do |f|
+      f.write @axlsx.to_stream.read
+    end
+  end
+
+  # New functionality as of 0.1.4 (serialize)
+  def test_works_without_apply_styles_serialize
+    filename = 'without_apply_styles_serialize'
     assert_equal nil, @workbook.styles_applied
     @workbook.add_worksheet do |sheet|
       sheet.add_row ['A1', 'B1']
@@ -24,9 +31,21 @@ class IntegrationTest < MiniTest::Test
     assert_equal 1, @workbook.style_index.count
   end
 
-  # Backwards compatibility with pre 0.1.4 versions
-  def test_works_with_apply_styles
-    filename = 'with_apply_styles'
+  # New functionality as of 0.1.4 (to_stream)
+  def test_works_without_apply_styles_to_stream
+    filename = 'without_apply_styles_to_stream'
+    assert_equal nil, @workbook.styles_applied
+    @workbook.add_worksheet do |sheet|
+      sheet.add_row ['A1', 'B1']
+      sheet.add_style 'A1:B1', b: true
+    end
+    to_stream(filename)
+    assert_equal 1, @workbook.style_index.count
+  end
+
+  # Backwards compatibility with pre 0.1.4 (serialize)
+  def test_works_with_apply_styles_serialize
+    filename = 'with_apply_styles_serialize'
     assert_equal nil, @workbook.styles_applied
     @workbook.add_worksheet do |sheet|
       sheet.add_row ['A1', 'B1']
@@ -35,6 +54,19 @@ class IntegrationTest < MiniTest::Test
     @workbook.apply_styles # important for backwards compatibility
     assert_equal 1, @workbook.style_index.count
     serialize(filename)
+  end
+
+  # Backwards compatibility with pre 0.1.4 (to_stream)
+  def test_works_with_apply_styles_to_stream
+    filename = 'with_apply_styles_to_stream'
+    assert_equal nil, @workbook.styles_applied
+    @workbook.add_worksheet do |sheet|
+      sheet.add_row ['A1', 'B1']
+      sheet.add_style 'A1:B1', b: true
+    end
+    @workbook.apply_styles # important for backwards compatibility
+    assert_equal 1, @workbook.style_index.count
+    to_stream(filename)
   end
 
   def test_table_with_borders

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -10,6 +10,28 @@ class IntegrationTest < MiniTest::Test
   def teardown
     return unless @filename
     @axlsx.serialize File.expand_path("../../tmp/#{@filename}.xlsx", __FILE__)
+    assert_equal true, @workbook.styles_applied
+  end
+
+  def test_works_without_apply_styles
+    @filename = 'without_apply_styles'
+    assert_equal nil, @workbook.styles_applied
+    @workbook.add_worksheet do |sheet|
+      sheet.add_row ['A1', 'B1']
+      sheet.add_style 'A1:B1', b: true
+    end
+  end
+
+  # Backwards compatibility for pre 0.1.4 versions
+  def test_works_with_apply_styles
+    @filename = 'with_apply_styles'
+    assert_equal nil, @workbook.styles_applied
+    @workbook.add_worksheet do |sheet|
+      sheet.add_row ['A1', 'B1']
+      sheet.add_style 'A1:B1', b: true
+    end
+    @workbook.apply_styles
+    assert_equal 1, @workbook.style_index.count
   end
 
   def test_table_with_borders
@@ -23,7 +45,6 @@ class IntegrationTest < MiniTest::Test
       sheet.add_row ['', 'Pizza', 'Frozen Foods',  4.99]
       sheet.column_widths 5, 20, 20, 20
 
-      # using AxlsxStyler DSL
       sheet.add_style 'B2:D2', b: true
       sheet.add_style 'B2:B6', b: true
       sheet.add_style 'B2:D2', bg_color: '95AFBA'

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -7,35 +7,38 @@ class IntegrationTest < MiniTest::Test
   end
 
   # Save files in case you'd like to see what the result is
-  def teardown
-    return unless @filename
-    @axlsx.serialize File.expand_path("../../tmp/#{@filename}.xlsx", __FILE__)
+  def serialize(filename)
+    @axlsx.serialize File.expand_path("../../tmp/#{filename}.xlsx", __FILE__)
     assert_equal true, @workbook.styles_applied
   end
 
+  # New functionality as of 0.1.4
   def test_works_without_apply_styles
-    @filename = 'without_apply_styles'
+    filename = 'without_apply_styles'
     assert_equal nil, @workbook.styles_applied
     @workbook.add_worksheet do |sheet|
       sheet.add_row ['A1', 'B1']
       sheet.add_style 'A1:B1', b: true
     end
-  end
-
-  # Backwards compatibility for pre 0.1.4 versions
-  def test_works_with_apply_styles
-    @filename = 'with_apply_styles'
-    assert_equal nil, @workbook.styles_applied
-    @workbook.add_worksheet do |sheet|
-      sheet.add_row ['A1', 'B1']
-      sheet.add_style 'A1:B1', b: true
-    end
-    @workbook.apply_styles
+    serialize(filename)
     assert_equal 1, @workbook.style_index.count
   end
 
+  # Backwards compatibility with pre 0.1.4 versions
+  def test_works_with_apply_styles
+    filename = 'with_apply_styles'
+    assert_equal nil, @workbook.styles_applied
+    @workbook.add_worksheet do |sheet|
+      sheet.add_row ['A1', 'B1']
+      sheet.add_style 'A1:B1', b: true
+    end
+    @workbook.apply_styles # important for backwards compatibility
+    assert_equal 1, @workbook.style_index.count
+    serialize(filename)
+  end
+
   def test_table_with_borders
-    @filename = 'borders_test'
+    filename = 'borders_test'
     @workbook.add_worksheet do |sheet|
       sheet.add_row
       sheet.add_row ['', 'Product', 'Category',  'Price']
@@ -55,13 +58,13 @@ class IntegrationTest < MiniTest::Test
       sheet.add_border 'B3:D3', edges: [:bottom], style: :medium
       sheet.add_border 'B3:D3', edges: [:bottom], style: :medium, color: '32f332'
     end
-    @workbook.apply_styles
+    serialize(filename)
     assert_equal 12, @workbook.style_index.count
     assert_equal 12 + 2, @workbook.style_index.keys.max
   end
 
   def test_duplicate_borders
-    @filename = 'duplicate_borders_test'
+    filename = 'duplicate_borders_test'
     @workbook.add_worksheet do |sheet|
       sheet.add_row
       sheet.add_row ['', 'B2', 'C2', 'D2']
@@ -71,13 +74,13 @@ class IntegrationTest < MiniTest::Test
       sheet.add_border 'B2:D4'
       sheet.add_border 'B2:D4'
     end
-    @workbook.apply_styles
+    serialize(filename)
     assert_equal 8, @workbook.style_index.count
     assert_equal 8, @workbook.styled_cells.count
   end
 
   def test_multiple_style_borders_on_same_sells
-    @filename = 'multiple_style_borders'
+    filename = 'multiple_style_borders'
     @workbook.add_worksheet do |sheet|
       sheet.add_row
       sheet.add_row ['', 'B2', 'C2', 'D2']
@@ -86,7 +89,7 @@ class IntegrationTest < MiniTest::Test
       sheet.add_border 'B2:D3', :all
       sheet.add_border 'B2:D2', edges: [:bottom], style: :thick, color: 'ff0000'
     end
-    @workbook.apply_styles
+    serialize(filename)
     assert_equal 6, @workbook.style_index.count
     assert_equal 6, @workbook.styled_cells.count
 
@@ -112,7 +115,7 @@ class IntegrationTest < MiniTest::Test
   end
 
   def test_table_with_num_fmt
-    @filename = 'num_fmt_test'
+    filename = 'num_fmt_test'
     t = Time.now
     day = 24 * 60 * 60
     @workbook.add_worksheet do |sheet|
@@ -124,14 +127,14 @@ class IntegrationTest < MiniTest::Test
       sheet.add_style 'A1:B1', b: true
       sheet.add_style 'A2:A4', format_code: 'YYYY-MM-DD hh:mm:ss'
     end
-    @workbook.apply_styles
+    serialize(filename)
     assert_equal 2, @workbook.style_index.count
     assert_equal 2 + 2, @workbook.style_index.keys.max
     assert_equal 5, @workbook.styled_cells.count
   end
 
   def test_duplicate_styles
-    @filename = 'duplicate_styles'
+    filename = 'duplicate_styles'
     @workbook.add_worksheet do |sheet|
       sheet.add_row %w(Index City)
       sheet.add_row [1, 'Ottawa']
@@ -142,13 +145,13 @@ class IntegrationTest < MiniTest::Test
       sheet.add_style 'A1:A3', b: true
       sheet.add_style 'A1:A3', b: true
     end
-    @workbook.apply_styles
+    serialize(filename)
     assert_equal 4, @workbook.styled_cells.count
     assert_equal 3, @workbook.style_index.count
   end
 
   def test_multiple_named_styles
-    @filename = 'multiple_named_styles'
+    filename = 'multiple_named_styles'
     bold_blue = { b: true, fg_color: '0000FF' }
     large = { sz: 16 }
     red = { fg_color: 'FF0000' }
@@ -160,7 +163,7 @@ class IntegrationTest < MiniTest::Test
       sheet.add_style 'A1:B1', bold_blue, large
       sheet.add_style 'A1:A3', red
     end
-    @workbook.apply_styles
+    serialize(filename)
     assert_equal 4, @workbook.styled_cells.count
     assert_equal 3, @workbook.style_index.count
   end

--- a/test/workbook_test.rb
+++ b/test/workbook_test.rb
@@ -5,5 +5,6 @@ class WorkbookTest < MiniTest::Test
     wb.add_styled_cell 'Cell 1'
     wb.add_styled_cell 'Cell 2'
     assert_equal ['Cell 1', 'Cell 2'].to_set, wb.styled_cells
+    assert_equal nil, wb.styles_applied
   end
 end


### PR DESCRIPTION
Patch `Axlsx::Package#serialize` and `Axlsx::Package#to_stream` methods so that the styles are indexed automatically when these methods are called. Implementation is suggested by @westonganger. The change is backwards compatible.

Also update and improve README.
