### PR TITLE
Add style merging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tmp
 mkmf.log
 *.xlsx
 *.xlsx#
+.DS_Store

--- a/lib/axlsx_styler.rb
+++ b/lib/axlsx_styler.rb
@@ -54,9 +54,12 @@ module Axlsx
       index = style_index.key(raw_style)
       if !index
         index = original_add_style.bind(self).(style)
-        self.style_index[index] ||= raw_style
+        self.style_index[index] = raw_style
       end
       return index
     end
+
+    private 
+
   end
 end

--- a/lib/axlsx_styler.rb
+++ b/lib/axlsx_styler.rb
@@ -11,7 +11,6 @@ Axlsx::Cell.send :include, AxlsxStyler::Axlsx::Cell
 
 module Axlsx
   class Package
-
     # Patches the original Axlsx::Package#serialize method so that styles are
     # applied when the workbook is saved
     original_serialize = instance_method(:serialize)
@@ -26,6 +25,38 @@ module Axlsx
     define_method :to_stream do |*args|
       workbook.apply_styles if !workbook.styles_applied
       original_to_stream.bind(self).(*args)
+    end
+  end
+
+  class Styles
+    # An index for cell styles
+    #   {
+    #     1 => < style_hash >,
+    #     2 => < style_hash >,
+    #     ...
+    #     K => < style_hash >
+    #   }
+    # where keys are Cell#raw_style and values are styles
+    # codes as per Axlsx::Style
+    attr_accessor :style_index
+
+    # Patches the original Axlsx::Styles#add_style method so that plain axlsx
+    # styles are added to the axlsx_styler style_index cache
+    original_add_style = instance_method(:add_style)
+    define_method :add_style do |style|
+      self.style_index ||= {}
+
+      raw_style = {type: :xf, name: 'Arial', sz: 11, family: 1}.merge(style)
+      if raw_style[:format_code]
+        raw_style.delete(:num_fmt)
+      end
+
+      index = style_index.key(raw_style)
+      if !index
+        index = original_add_style.bind(self).(style)
+        self.style_index[index] ||= raw_style
+      end
+      return index
     end
   end
 end

--- a/lib/axlsx_styler/axlsx_cell.rb
+++ b/lib/axlsx_styler/axlsx_cell.rb
@@ -21,12 +21,14 @@ module AxlsxStyler
         # using deep_merge from active_support:
         # with regular Hash#merge adding borders fails miserably
         new_style = raw_style.deep_merge style
+
         if with_border?(raw_style) && with_border?(style)
           border_at = (raw_style[:border][:edges] || all_edges) + (style[:border][:edges] || all_edges)
           new_style[:border][:edges] = border_at.uniq.sort
         elsif with_border?(style)
           new_style[:border] = style[:border]
         end
+
         self.raw_style = new_style
       end
 

--- a/lib/axlsx_styler/axlsx_workbook.rb
+++ b/lib/axlsx_styler/axlsx_workbook.rb
@@ -10,17 +10,6 @@ module AxlsxStyler
       # users that still explicitly call @workbook.apply_styles
       attr_accessor :styles_applied
 
-      # An index for cell styles
-      #   {
-      #     1 => < style_hash >,
-      #     2 => < style_hash >,
-      #     ...
-      #     K => < style_hash >
-      #   }
-      # where keys are Cell#raw_style and values are styles
-      # codes as per Axlsx::Style
-      attr_accessor :style_index
-
       def add_styled_cell(cell)
         self.styled_cells ||= Set.new
         self.styled_cells << cell
@@ -29,28 +18,11 @@ module AxlsxStyler
       def apply_styles
         return unless styled_cells
         styled_cells.each do |cell|
-          set_style_index(cell)
+          cell.style = styles.add_style(cell.raw_style)
         end
         self.styles_applied = true
       end
 
-      private
-
-      # Check if style code
-      def set_style_index(cell)
-        self.style_index ||= {}
-
-        index_item = style_index.select { |_, v| v == cell.raw_style }.first
-        if index_item
-          cell.style = index_item.first
-        else
-          old_style = cell.raw_style.dup
-          new_style = styles.add_style(cell.raw_style)
-          cell.style = new_style
-          # cell.raw_style.delete(:num_fmt)
-          style_index[new_style] = old_style
-        end
-      end
     end
   end
 end

--- a/lib/axlsx_styler/axlsx_workbook.rb
+++ b/lib/axlsx_styler/axlsx_workbook.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'active_support/core_ext/hash/deep_merge'
 
 module AxlsxStyler
   module Axlsx
@@ -6,7 +7,7 @@ module AxlsxStyler
       # An array that holds all cells with styles
       attr_accessor :styled_cells
 
-      # Checks if styles are idexed to make it work for pre 0.1.5 version
+      # Checks if styles are indexed to make it work for pre 0.1.5 version
       # users that still explicitly call @workbook.apply_styles
       attr_accessor :styles_applied
 
@@ -17,8 +18,16 @@ module AxlsxStyler
 
       def apply_styles
         return unless styled_cells
+  
         styled_cells.each do |cell|
-          cell.style = styles.add_style(cell.raw_style)
+          if styles.style_index && styles.style_index[cell.style]
+            current_style = styles.style_index[cell.style]
+            new_style = current_style.deep_merge(cell.raw_style)
+          else
+            new_style = cell.raw_style
+          end
+
+          cell.style = styles.add_style(new_style)
         end
         self.styles_applied = true
       end

--- a/test/cell_test.rb
+++ b/test/cell_test.rb
@@ -9,6 +9,6 @@ class CellTest < MiniTest::Test
     cell = row.cells.first
 
     cell.add_style b: true
-    assert_equal({ b: true }, cell.raw_style)
+    assert_equal({b: true}, cell.raw_style)
   end
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -111,7 +111,7 @@ class IntegrationTest < MiniTest::Test
     assert_equal 8, @workbook.styled_cells.count
   end
 
-  def test_multiple_style_borders_on_same_sells
+  def test_multiple_style_borders_on_same_cells
     filename = 'multiple_style_borders'
     @workbook.add_worksheet do |sheet|
       sheet.add_row
@@ -208,7 +208,7 @@ class IntegrationTest < MiniTest::Test
 
   # Overriding borders (part 1)
   def test_mixed_borders_1
-    @filename = 'mixed_borders_1'
+    filename = 'mixed_borders_1'
     @workbook.add_worksheet do |sheet|
       sheet.add_row
       sheet.add_row ['', '1', '2', '3']
@@ -220,11 +220,12 @@ class IntegrationTest < MiniTest::Test
     @workbook.apply_styles
     assert_equal 9, @workbook.styled_cells.count
     assert_equal 2, @workbook.styles.style_index.count
+    serialize(filename)
   end
 
   # Overriding borders (part 2)
   def test_mixed_borders
-    @filename = 'mixed_borders_2'
+    filename = 'mixed_borders_2'
     @workbook.add_worksheet do |sheet|
       sheet.add_row
       sheet.add_row ['', '1', '2', '3']
@@ -236,45 +237,50 @@ class IntegrationTest < MiniTest::Test
     @workbook.apply_styles
     assert_equal 8, @workbook.styled_cells.count
     assert_equal 6, @workbook.styles.style_index.count
+    serialize(filename)
   end
 
   def test_merge_styles_1
-    @filename = 'merge_styles_1'
+    filename = 'merge_styles_1'
     @workbook.add_worksheet do |sheet|
       sheet.add_row
       sheet.add_row ['', '1', '2', '3']
       sheet.add_row ['', '4', '5', '6']
       sheet.add_row ['', '7', '8', '9']
       sheet.add_style 'B2:D4', b: true
-      sheet.add_style 'B2:D4', border: { style: :thin, color: '000000' }
+      sheet.add_border 'B2:D4', { style: :thin, color: '000000' }
     end
     @workbook.apply_styles
-    assert_equal 1, @workbook.styles.style_index.count
+    assert_equal 9, @workbook.styles.style_index.count
+    serialize(filename)
   end
 
   def test_merge_styles_2
-    @filename = 'merge_styles_2'
+    filename = 'merge_styles_2'
     bold = @workbook.styles.add_style b: true
 
     @workbook.add_worksheet do |sheet|
       sheet.add_row ['A1', 'B1'], style: [nil, bold]
-      sheet.add_row ['A2', 'B2']
-      sheet.add_border 'A1:B2'
+      sheet.add_row ['A2', 'B2'], style: bold
+      sheet.add_row ['A3', 'B3']
+      sheet.add_style 'A1:A2', i: true
     end
     @workbook.apply_styles
-    assert_equal 5, @workbook.styles.style_index.count
+    assert_equal 3, @workbook.styles.style_index.count
+    serialize(filename)
   end
   
   def test_merge_styles_3
-    @filename = 'merge_styles_3'
+    filename = 'merge_styles_3'
     bold = @workbook.styles.add_style b: true
 
     @workbook.add_worksheet do |sheet|
       sheet.add_row ['A1', 'B1'], style: [nil, bold]
       sheet.add_row ['A2', 'B2']
-      sheet.add_style 'B1:B2', bg_color: 'ff0000'
+      sheet.add_style 'B1:B2', bg_color: 'FF0000'
     end
     @workbook.apply_styles
-    assert_equal 2, @workbook.styles.style_index.count
+    assert_equal 3, @workbook.styles.style_index.count
+    serialize(filename)
   end
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -28,7 +28,7 @@ class IntegrationTest < MiniTest::Test
       sheet.add_style 'A1:B1', b: true
     end
     serialize(filename)
-    assert_equal 1, @workbook.style_index.count
+    assert_equal 1, @workbook.styles.style_index.count
   end
 
   # New functionality as of 0.1.5 (to_stream)
@@ -40,7 +40,7 @@ class IntegrationTest < MiniTest::Test
       sheet.add_style 'A1:B1', b: true
     end
     to_stream(filename)
-    assert_equal 1, @workbook.style_index.count
+    assert_equal 1, @workbook.styles.style_index.count
   end
 
   # Backwards compatibility with pre 0.1.5 (serialize)
@@ -52,7 +52,7 @@ class IntegrationTest < MiniTest::Test
       sheet.add_style 'A1:B1', b: true
     end
     @workbook.apply_styles # important for backwards compatibility
-    assert_equal 1, @workbook.style_index.count
+    assert_equal 1, @workbook.styles.style_index.count
     serialize(filename)
   end
 
@@ -65,7 +65,7 @@ class IntegrationTest < MiniTest::Test
       sheet.add_style 'A1:B1', b: true
     end
     @workbook.apply_styles # important for backwards compatibility
-    assert_equal 1, @workbook.style_index.count
+    assert_equal 1, @workbook.styles.style_index.count
     to_stream(filename)
   end
 
@@ -91,8 +91,8 @@ class IntegrationTest < MiniTest::Test
       sheet.add_border 'B3:D3', edges: [:bottom], style: :medium, color: '32f332'
     end
     serialize(filename)
-    assert_equal 12, @workbook.style_index.count
-    assert_equal 12 + 2, @workbook.style_index.keys.max
+    assert_equal 12, @workbook.styles.style_index.count
+    assert_equal 12 + 2, @workbook.styles.style_index.keys.max
   end
 
   def test_duplicate_borders
@@ -107,7 +107,7 @@ class IntegrationTest < MiniTest::Test
       sheet.add_border 'B2:D4'
     end
     serialize(filename)
-    assert_equal 8, @workbook.style_index.count
+    assert_equal 8, @workbook.styles.style_index.count
     assert_equal 8, @workbook.styled_cells.count
   end
 
@@ -122,7 +122,7 @@ class IntegrationTest < MiniTest::Test
       sheet.add_border 'B2:D2', edges: [:bottom], style: :thick, color: 'ff0000'
     end
     serialize(filename)
-    assert_equal 6, @workbook.style_index.count
+    assert_equal 6, @workbook.styles.style_index.count
     assert_equal 6, @workbook.styled_cells.count
 
     b2_cell_style = {
@@ -130,20 +130,26 @@ class IntegrationTest < MiniTest::Test
         style: :thick,
         color: 'ff0000',
         edges: [:bottom, :left, :top]
-      }
+      },
+      type: :xf,
+      name: 'Arial',
+      sz: 11,
+      family: 1
     }
-    assert_equal b2_cell_style, @workbook.style_index
-      .find { |_, v| v[:border][:edges] == [:bottom, :left, :top] }[1]
+    assert_equal b2_cell_style, @workbook.styles.style_index.values.find{|x| x == b2_cell_style}
 
     d3_cell_style = {
       border: {
         style: :thin,
         color: '000000',
         edges: [:bottom, :right]
-      }
+      },
+      type: :xf,
+      name: 'Arial',
+      sz: 11,
+      family: 1
     }
-    assert_equal d3_cell_style, @workbook.style_index
-      .find { |_, v| v[:border][:edges] == [:bottom, :right] }[1]
+    assert_equal d3_cell_style, @workbook.styles.style_index.values.find{|x| x == d3_cell_style}
   end
 
   def test_table_with_num_fmt
@@ -160,8 +166,8 @@ class IntegrationTest < MiniTest::Test
       sheet.add_style 'A2:A4', format_code: 'YYYY-MM-DD hh:mm:ss'
     end
     serialize(filename)
-    assert_equal 2, @workbook.style_index.count
-    assert_equal 2 + 2, @workbook.style_index.keys.max
+    assert_equal 2, @workbook.styles.style_index.count
+    assert_equal 2 + 2, @workbook.styles.style_index.keys.max
     assert_equal 5, @workbook.styled_cells.count
   end
 
@@ -179,7 +185,7 @@ class IntegrationTest < MiniTest::Test
     end
     serialize(filename)
     assert_equal 4, @workbook.styled_cells.count
-    assert_equal 3, @workbook.style_index.count
+    assert_equal 3, @workbook.styles.style_index.count
   end
 
   def test_multiple_named_styles
@@ -197,7 +203,7 @@ class IntegrationTest < MiniTest::Test
     end
     serialize(filename)
     assert_equal 4, @workbook.styled_cells.count
-    assert_equal 3, @workbook.style_index.count
+    assert_equal 3, @workbook.styles.style_index.count
   end
 
   # Overriding borders (part 1)
@@ -213,7 +219,7 @@ class IntegrationTest < MiniTest::Test
     end
     @workbook.apply_styles
     assert_equal 9, @workbook.styled_cells.count
-    assert_equal 2, @workbook.style_index.count
+    assert_equal 2, @workbook.styles.style_index.count
   end
 
   # Overriding borders (part 2)
@@ -229,6 +235,46 @@ class IntegrationTest < MiniTest::Test
     end
     @workbook.apply_styles
     assert_equal 8, @workbook.styled_cells.count
-    assert_equal 6, @workbook.style_index.count
+    assert_equal 6, @workbook.styles.style_index.count
+  end
+
+  def test_merge_styles_1
+    @filename = 'merge_styles_1'
+    @workbook.add_worksheet do |sheet|
+      sheet.add_row
+      sheet.add_row ['', '1', '2', '3']
+      sheet.add_row ['', '4', '5', '6']
+      sheet.add_row ['', '7', '8', '9']
+      sheet.add_style 'B2:D4', b: true
+      sheet.add_style 'B2:D4', border: { style: :thin, color: '000000' }
+    end
+    @workbook.apply_styles
+    assert_equal 1, @workbook.styles.style_index.count
+  end
+
+  def test_merge_styles_2
+    @filename = 'merge_styles_2'
+    bold = @workbook.styles.add_style b: true
+
+    @workbook.add_worksheet do |sheet|
+      sheet.add_row ['A1', 'B1'], style: [nil, bold]
+      sheet.add_row ['A2', 'B2']
+      sheet.add_border 'A1:B2'
+    end
+    @workbook.apply_styles
+    assert_equal 5, @workbook.styles.style_index.count
+  end
+  
+  def test_merge_styles_3
+    @filename = 'merge_styles_3'
+    bold = @workbook.styles.add_style b: true
+
+    @workbook.add_worksheet do |sheet|
+      sheet.add_row ['A1', 'B1'], style: [nil, bold]
+      sheet.add_row ['A2', 'B2']
+      sheet.add_style 'B1:B2', bg_color: 'ff0000'
+    end
+    @workbook.apply_styles
+    assert_equal 2, @workbook.styles.style_index.count
   end
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -242,10 +242,12 @@ class IntegrationTest < MiniTest::Test
 
   def test_merge_styles_1
     filename = 'merge_styles_1'
+    bold = @workbook.styles.add_style b: true
+
     @workbook.add_worksheet do |sheet|
       sheet.add_row
-      sheet.add_row ['', '1', '2', '3']
-      sheet.add_row ['', '4', '5', '6']
+      sheet.add_row ['', '1', '2', '3'], style: [nil, bold]
+      sheet.add_row ['', '4', '5', '6'], style: bold
       sheet.add_row ['', '7', '8', '9']
       sheet.add_style 'B2:D4', b: true
       sheet.add_border 'B2:D4', { style: :thin, color: '000000' }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,3 +2,5 @@ require 'axlsx_styler'
 require 'minitest/autorun'
 require 'minitest/pride'
 require 'awesome_print'
+
+mkdir_p(File.expand_path("../../tmp", __FILE__))


### PR DESCRIPTION
Addresses issue #14

It now only safely patches `Axlsx::Styles.add_style` to implement a style cache. Style index had to be moved from the Workbook to Styles because you cant access the workbook from the `add_styles` method. Tests are all passing but new ones added for this probably aren't super meaningful yet.